### PR TITLE
Fixing issues in sb2 build

### DIFF
--- a/build-recipe-spec
+++ b/build-recipe-spec
@@ -77,7 +77,7 @@ recipe_prepare_spec() {
 	    echo -----------------------------------------------------------------
 	    echo "I have the following modifications for $RECIPEFILE:"
 	    sed -e "/^%changelog/q" $BUILD_ROOT$TOPDIR/SOURCES/$RECIPEFILE > $BUILD_TARGET/.spec.t1
-	    sed -e "/^%changelog/q" $BUILD_ROOT/.spec.new > $BUILD_TARGET/.spec.t2
+	    sed -e "/^%changelog/q" $BUILD_TARGET/.spec.new > $BUILD_TARGET/.spec.t2
 	    diff $BUILD_TARGET/.spec.t1 $BUILD_TARGET/.spec.t2
 	    rm -f $BUILD_TARGET/.spec.t1 $BUILD_TARGET/.spec.t2
 	    mv $BUILD_TARGET/.spec.new $BUILD_ROOT$TOPDIR/SOURCES/$RECIPEFILE

--- a/init_buildsystem
+++ b/init_buildsystem
@@ -1023,7 +1023,7 @@ done
 
 if test -e $BUILD_TARGET/usr/share/zoneinfo/UTC ; then
     for PROG in /usr/sbin/zic /usr/bin/zic /bin/zic /sbin/zic ; do
-        test -x $BUILD_TARGET/$PROG  && enter_target needroot $PROG -l $(readlink -f /usr/share/zoneinfo/UTC)
+        test -x $BUILD_TARGET/$PROG  && enter_target needroot bash -c "$PROG -l \$(readlink -f /usr/share/zoneinfo/UTC)"
     done
 fi
 


### PR DESCRIPTION
Currently setting localtime and listing spec file modifications are not working in sb2 builds. These commits fix the issues.
